### PR TITLE
Ensure Principal and Group objects comply with the schema.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,14 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    # Force a newer PyPy on the old 'precise' CI image
-    # in order to install 'cryptography' needed for coveralls
-    # After September 2017 this should be the default and the version
-    # pin can be removed.
-    - pypy-5.6.0
-    - pypy3.5-5.8.0
+    - pypy
+    - pypy3
 install:
     - pip install -U setuptools pip
     - pip install -U coveralls coverage
     - pip install -U -e .[test]
 script:
-    - coverage run -m zope.testrunner --test-path=src
+    - coverage run -m zope.testrunner --test-path=src --auto-color
 after_success:
     - coveralls
 notifications:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@
 4.1.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix principal and group objects registered in ZCML or directly with
+  the principalregistry being invalid under Python 2 (having byte
+  strings for ``id`` instead of text strings).
+  See https://github.com/zopefoundation/zope.principalregistry/issues/7
 
 
 4.1.0 (2017-09-04)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,8 +1,1 @@
-# this is a namespace package
-try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
-    import pkgutil
-    __path__ = pkgutil.extend_path(__path__, __name__)
-
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/principalregistry/README.rst
+++ b/src/zope/principalregistry/README.rst
@@ -30,11 +30,31 @@ There are principals that can log in:
     ...    </configure>
     ... """)
 
-    >>> import pprint
     >>> from zope.principalregistry.principalregistry import principalRegistry
     >>> [p] = principalRegistry.getPrincipals('')
     >>> p.id, p.title, p.description, p.getLogin(), p.validate('123')
     ('zope.manager', u'Manager', u'System Manager', u'admin', True)
+
+We can verify that it conforms to the
+:class:`zope.security.interfaces.IPrincipal` interface:
+
+    >>> from zope.security.interfaces import IPrincipal
+    >>> from zope.interface.verify import verifyObject
+    >>> from zope.schema import getValidationErrors
+    >>> verifyObject(IPrincipal, p)
+    True
+    >>> getValidationErrors(IPrincipal, p)
+    []
+
+In fact, it's actually a
+:class:`zope.security.interfaces.IGroupAwarePrincipal`:
+
+    >>> from zope.security.interfaces import IGroupAwarePrincipal
+    >>> verifyObject(IGroupAwarePrincipal, p)
+    True
+    >>> getValidationErrors(IGroupAwarePrincipal, p)
+    []
+
 
 The unauthenticated principal
 =============================
@@ -59,13 +79,21 @@ There is the unauthenticated principal:
     >>> p.id, p.title, p.description
     ('zope.unknown', u'Anonymous user', u"A person we don't know")
 
+It implements :class:`zope.authentication.interfaces.IUnauthenticatedPrincipal`:
+
+    >>> from zope.authentication import interfaces
+    >>> verifyObject(interfaces.IUnauthenticatedPrincipal, p)
+    True
+    >>> getValidationErrors(interfaces.IUnauthenticatedPrincipal, p)
+    []
+
+
 The unauthenticated principal will also be registered as a utility.
 This is to provide easy access to the data defined for the principal so
 that other (more featureful) principal objects can be created for the
 same principal.
 
     >>> from zope import component
-    >>> from zope.authentication import interfaces
     >>> p = component.getUtility(interfaces.IUnauthenticatedPrincipal)
     >>> p.id, p.title, p.description
     ('zope.unknown', u'Anonymous user', u"A person we don't know")
@@ -95,6 +123,13 @@ IUnauthenticatedGroup:
     >>> g = component.getUtility(interfaces.IUnauthenticatedGroup)
     >>> g.id, g.title, g.description
     ('zope.unknowngroup', u'Anonymous users', u"People we don't know")
+
+It implements :class:`zope.authentication.interfaces.IUnauthenticatedGroup`:
+
+    >>> verifyObject(interfaces.IUnauthenticatedGroup, g)
+    True
+    >>> getValidationErrors(interfaces.IUnauthenticatedGroup, g)
+    []
 
 The unauthenticatedGroup directive also updates the group of the
 unauthenticated principal:
@@ -188,6 +223,13 @@ It defines an IAuthenticatedGroup utility:
     >>> g.id, g.title, g.description
     ('zope.authenticated', u'Authenticated users', u'People we know')
 
+It implements :class:`zope.authentication.interfaces.IUnauthenticatedGroup`:
+
+    >>> verifyObject(interfaces.IAuthenticatedGroup, g)
+    True
+    >>> getValidationErrors(interfaces.IAuthenticatedGroup, g)
+    []
+
 It also adds it self to the groups of any non-group principals already
 defined, and, when non-group principals are defined, they put
 themselves in the group if it's defined:
@@ -251,6 +293,13 @@ The everybodyGroup directive defines an IEveryoneGroup utility:
     >>> g = component.getUtility(interfaces.IEveryoneGroup)
     >>> g.id, g.title, g.description
     ('zope.everybody', u'Everybody', u'All People')
+
+It implements :class:`zope.authentication.interfaces.IEveryoneGroup`:
+
+    >>> verifyObject(interfaces.IEveryoneGroup, g)
+    True
+    >>> getValidationErrors(interfaces.IEveryoneGroup, g)
+    []
 
 It also adds it self to the groups of any non-group principals already
 defined, and, when non-group principals are defined, they put

--- a/src/zope/principalregistry/metadirectives.py
+++ b/src/zope/principalregistry/metadirectives.py
@@ -16,11 +16,20 @@
 from zope.interface import Interface
 from zope.schema import Id, TextLine
 
+class TextId(Id):
+    """
+    An Id that is the text type instead of a native string.
+
+    This is required because ``IPrincipal`` defines *id* to be
+    the text type.
+    """
+
+    _type = str if str is not bytes else unicode
 
 class IBasePrincipalDirective(Interface):
     """Base interface for principal definition directives."""
 
-    id = Id(
+    id = TextId(
         title=u"Id",
         description=u"Id as which this object will be known and used.",
         required=True)


### PR DESCRIPTION
The ZCML and management methods make sure that `id` is text, especially on Python 2.

All the added tests passed on Python 3 but failed on Python 2 before the code changes.

Fixes #7